### PR TITLE
Authenticated requests to private kroki

### DIFF
--- a/pystructurizr/config.py
+++ b/pystructurizr/config.py
@@ -1,0 +1,3 @@
+URL = "https://kroki-server-twjog3b3pq-ew.a.run.app/structurizr/svg"
+# you can also use the hosted version of kroki if you don't want to run your own instance:
+# URL = "https://kroki.io/structurizr/svg"


### PR DESCRIPTION
This PR 
* makes the kroki server URL configurable
* replaces the default `kroki.io` domain with the URL to a selfhosted instance
* introduces authentication using Google default credentials in case the server is running on Cloud Run

@ruwann