### PR TITLE
Updates after testing CC example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ build/
 gcs_credentials.json
 
 .idea/
+
+# Virtual environment
+.venv/
+venv/

--- a/examples/cc_2023Q3/README.md
+++ b/examples/cc_2023Q3/README.md
@@ -17,21 +17,55 @@ You can leverage Structurizr DSL to generate C4 diagrams by defining a *Workspac
     gcloud config set project decisive-mapper-401607
     ```
 
-2. Create your first diagram
+2. Set up virtual environment
 
     ```commandline
+    python3 -m venv --prompt="c4-models" .venv
+    source .venv/bin/activate
     pip install -e .
+    ```
+
+    <details>
+    <summary>In case of problems</summary>
+    If you encounter something like:
+
+    <pre>
+        ```
+        error: invalid command 'bdist_wheel'
+        ----------------------------------------
+        ERROR: Failed building wheel for pystructurizr
+        ```
+    </pre>
+
+    You should be able to solve it by running `pip install wheel`
+    </details>
+
+3. Create your first diagram
+
+    ```commandline
     cd examples/cc_2023Q3
-    pystructurizr dev --view systemlandscapeview
+    pystructurizr render --view systemlandscapeview
     ```
 
     At this point a browser window should open that renders the System Landscape View of a sample system.
-    The rendered diagram will update automatically as you modify the underlying [workspace.py](./workspace.py). Use `Ctrl-C` to exit.
 
-3. To generate a more detailed diagram showing the internals of the **Fantastic Web App**:
+    <details>
+    <summary>For more adventurous users</summary>
+    You can also use
+    <pre>pystructurizr dev --view systemlandscapeview</pre>
+
+    It will also open a browser window that renders your diagram.
+    The difference is that the rendered diagram will update automatically as you modify the underlying [workspace.py](./workspace.py). Use `Ctrl-C` to exit.
+
+    However, it will launch a http server in the background which will not
+    be stopped appropriately if there is an error in your diagram code.
+    You'll have to find the right process ID with `ps aux` and kill it with `kill -9 <PID>`
+    </details>
+
+4. To generate a more detailed diagram showing the internals of the **Fantastic Web App**:
 
     ```commandline
-    pystructurizr dev --view containerview_webapp
+    pystructurizr render --view containerview_webapp
     ```
 
 ### 2. Get diagramming

--- a/examples/cc_2023Q3/output/index.html
+++ b/examples/cc_2023Q3/output/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            overflow: auto;
+        }
+
+    </style>
+</head>
+<body>
+    <img src="diagram.svg" />
+</body>
+</html>

--- a/pystructurizr/cli.py
+++ b/pystructurizr/cli.py
@@ -3,6 +3,7 @@ import json
 import os
 import shutil
 import subprocess
+import webbrowser
 
 import click
 
@@ -52,6 +53,24 @@ def dev(view):
         await observe_modules(modules_to_watch, async_behavior)
 
     asyncio.run(observe_loop())
+
+
+@click.command()
+@click.option('--view', prompt='Your view file (e.g. examples.single_file_example)',
+              help='The view file to render.')
+def render(view):
+    click.echo("Rendering SVG diagram...")
+    diagram_code, _ = generate_diagram_code_in_child_process(view)
+
+    async def _async_behavior():
+        # Generate SVG
+        await generate_svg(diagram_code, 'output')
+
+    asyncio.run(_async_behavior())
+    filename = f'output/{view}.svg'
+    shutil.copy('output/diagram.svg', filename)
+    print(f"Rendered SVG saved in {filename}")
+    webbrowser.open_new_tab("output/index.html")
 
 
 @click.command()


### PR DESCRIPTION
This PR

- adds a `render` command to render an SVG and open it in a new browser tab
- expands the README with more detailed instructions
- hopefully fixes the `dev` command